### PR TITLE
feat: Mejora en codigos HTTP y validacion de proyectos

### DIFF
--- a/services/consulta_proyecto_academico_service.go
+++ b/services/consulta_proyecto_academico_service.go
@@ -17,9 +17,14 @@ func PeticionProyectos() (APIResponseDTO requestresponse.APIResponse) {
 	errproyecto := request.GetJson("http://"+beego.AppConfig.String("ProyectoAcademicoService")+"/tr_proyecto_academico/", &proyectos)
 
 	if errproyecto == nil {
-		manejoProyectosGetAll(&proyectos)
-		APIResponseDTO = requestresponse.APIResponseDTO(true, 200, proyectos)
-		return APIResponseDTO
+		if len(proyectos) > 0 {
+			if len(proyectos[0]) > 0 {
+				manejoProyectosGetAll(&proyectos)
+				return requestresponse.APIResponseDTO(true, 200, proyectos)
+			}
+		}
+		// Si no hay proyectos o el primer proyecto está vacío
+		return requestresponse.APIResponseDTO(true, 204, nil, "No se encontraron proyectos")
 	} else {
 		APIResponseDTO = requestresponse.APIResponseDTO(false, 400, nil, errproyecto.Error())
 		return APIResponseDTO
@@ -178,7 +183,7 @@ func PeticionProyectosGetOneId(idStr string) (APIResponseDTO requestresponse.API
 			unidades = append(unidades, unidadTem)
 		}
 	}
-	
+
 	if proyectos[0]["ProyectoAcademico"] != nil && unidadesResponse["Data"] != nil {
 		response, ok := validarProyecto(errproyecto, errunidad, &proyectos, unidades, idUnidad)
 		if ok {
@@ -205,7 +210,7 @@ func InhabilitarProyecto(idStr string, data []byte) (APIResponseDTO requestrespo
 		} else {
 			APIResponseDTO = requestresponse.APIResponseDTO(true, 200, nil)
 		}
-	}else {
+	} else {
 		APIResponseDTO = requestresponse.APIResponseDTO(false, 400, nil, err.Error())
 	}
 	return APIResponseDTO
@@ -237,8 +242,8 @@ func PeticionRegistrosGetRegistroId(idStr string) (APIResponseDTO requestrespons
 	if errproyecto == nil {
 		manejoRegistrosGetRegistroId(&registros)
 		APIResponseDTO = requestresponse.APIResponseDTO(true, 200, registros)
-    } else {
-        APIResponseDTO = requestresponse.APIResponseDTO(false, 400, nil, errproyecto.Error())
-    }
+	} else {
+		APIResponseDTO = requestresponse.APIResponseDTO(false, 400, nil, errproyecto.Error())
+	}
 	return APIResponseDTO
 }


### PR DESCRIPTION
- Cuando no existe ningun proyecto academico registrado en el sistema el mid no gestionaba bien la respuesta del crud y se generaba un error 500, ahora si la peticion al crud de proyectos generar error, retorna un 400, si no hay proyectos un 204, si hay proyectos un 200.
--- 
udistrital/sga_documentacion#434